### PR TITLE
add simple stub for non-linux installs

### DIFF
--- a/epoll.js
+++ b/epoll.js
@@ -1,2 +1,9 @@
-module.exports = require('bindings')('epoll.node');
-
+module.exports = (() => {
+  const osType = require('os').type();
+  if (osType == 'Linux') {
+    require('bindings')('epoll.node');
+  } else {
+    console.warn(`epoll is built for Linux. Reported OS: ${osType}. Begin mock mode.`);
+    return { Epoll: {} }
+  }
+})()


### PR DESCRIPTION
Just a small change to make it clearer to users that epoll is only supported on Linux. This change should also make it easier to mock things out in case someone is dev'ing on a mac or windows machine - but good mocking may require a little more work.