### PR TITLE
#40 Add node-gyp to package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.14.1"
+    "nan": "^2.14.1",
+    "node-gyp": "^7.0.0"
   },
   "devDependencies": {
     "jshint": "^2.11.0"


### PR DESCRIPTION
PR adds node-gyp to the package dependencies, which makes this package installable via Yarn PnP, and removes the requirement that node-gyp be installed already.

Fixes #40